### PR TITLE
colour params saving form radio button selection

### DIFF
--- a/app/assets/stylesheets/components/_checkbox.scss
+++ b/app/assets/stylesheets/components/_checkbox.scss
@@ -1,12 +1,37 @@
-.checkbox {
-    display:inline-block;
-    opacity:0;
+.checkbox-div {
+    position: relative;
 }
 
-.checkbox::selection {
-//   border: white;
+.checkbox-element {
+    position: absolute;
+    transform: scale(0);
 }
 
-// label:hover {
-//     color: black;
-// }
+.checkbox-element + label {
+    cursor: pointer;
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    background-color: grey;
+    color: black;
+    border-radius: 10px;
+    font-weight: 500;
+    font-size: 40px;
+    width: 250px;
+    height: 250px;
+    margin: 7px;
+}
+
+.checkbox-element:checked + label {
+    color: white; 
+    filter: brightness(110%);
+    transform: scale(1.05);
+    border: 5px solid white;
+  }
+
+  .checkbox-element:hover + label {
+    color: white; 
+    filter: brightness(110%);
+    transform: scale(1.05);
+    border: 5px solid white;
+}

--- a/app/controllers/movie_results_controller.rb
+++ b/app/controllers/movie_results_controller.rb
@@ -11,7 +11,6 @@ class MovieResultsController < ApplicationController
   def create_suggestion
     genre = @colour_genre_key[params[:colour].to_sym]
     movie_candidates = Movie.where(genre: genre)
-    raise
 
     year = params[:year].to_i..(params[:year].to_i + 10)
     movie_candidates = movie_candidates.where(year: year)

--- a/app/views/movie_results/_colour_form.html.erb
+++ b/app/views/movie_results/_colour_form.html.erb
@@ -2,13 +2,12 @@
   <h2>What's your favourite colour?</h2>
 </div>
 <div class="">
-      <% @colour_hash_key.each do |colour| %>
-        <div class="colour-button m-2" style="background-color:<%=colour[1]%>;">
-          <%# <%= f.i "#{colour[0]}", name: "colour"%>
-          <label for=<%="#{colour[0]}"%>><%="#{colour[0]}"%></label>
-          <input id=<%="#{colour[0]}"%> name="" type="checkbox" value="" class="checkbox" />
-          
-          <%# <%= check_box_tag("#{colour[0]}"), name: "colour" %>
+    <div class="d-flex flex-wrap justify-content-center">
+      <% @colour_hash_key.values.shuffle.each do |colour| %>
+       <div class="checkbox-div">
+          <%= radio_button_tag "colour", @colour_hash_key.key(colour), false, class: "checkbox-element" %>
+          <label for="colour_<%=@colour_hash_key.key(colour)%>" style="background-color:<%=colour%>;"><%=@colour_hash_key.key(colour)%></label>
         </div>
       <% end %>
+    </div>
 </div>


### PR DESCRIPTION
This was quite satisfying to get done, although...some of things holding up were so specific it was frustrating. 

Anyway, the nice thing about this is we can copy it for all the questions. So before our presentation tomorrow we can do the Year and Mood as well quite easily. The create_suggestion works now to the suggestion page (no saving though but it's there to be saved).

You can now select any option on the form and it acts like a radio button - only one option can be selected.
Whatever option is selected is passed to the params as a colour and used to pick a genre. 

Updates -> once selected all others should change style -> need JS
Need to update the selected style vs. the hover style. 