### PR TITLE
now all anselections of questions remove other options

### DIFF
--- a/app/assets/stylesheets/components/_colour_button.scss
+++ b/app/assets/stylesheets/components/_colour_button.scss
@@ -13,7 +13,7 @@
     margin: 7px;
 }
 
-:checked + label {
+.colour-btn:checked + label {
     color: white; 
     filter: brightness(90%);
     transform: scale(1.05);

--- a/app/assets/stylesheets/pages/_questions.scss
+++ b/app/assets/stylesheets/pages/_questions.scss
@@ -29,9 +29,10 @@
 
   #nextBtn {
     background-color: #FFCA14;
+    font-size: 18px;
     border-radius: 8px;
     border: 4px solid white;
-    padding: 15px;
+    padding: 8px 18px;
     color: black;
     margin-top: 30px ;
   }

--- a/app/javascript/controllers/question_controller.js
+++ b/app/javascript/controllers/question_controller.js
@@ -2,7 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="question"
 export default class extends Controller {
-  static targets = ["next", "colour"]
+  static targets = ["next"]
 
   connect() {
     // something on connection is flashing before the following. 
@@ -10,6 +10,7 @@ export default class extends Controller {
     this.randomTabIndex = Math.floor(Math.random() * this.forms.length)
     this.forms[this.randomTabIndex].classList.remove("d-none")
     this.forms[this.randomTabIndex].classList.add("show")
+    this.reg = /[_^].+/
   }
 
   next(event) {
@@ -29,16 +30,16 @@ export default class extends Controller {
   }
 
   select(event) {
-    let colourID = event.target.parentElement.firstChild.nextSibling.id
-    console.log(colourID)
-    let allButtons = document.getElementsByClassName("colour-btn")
-    Array.from(allButtons).forEach((button) => {
-      if (button.id != colourID) {
+    let longID = event.target.parentElement.firstChild.nextSibling.id
+    let id = longID.replace(this.reg, "")
+    if (id == "colour") { this.allButtons = document.getElementsByClassName("colour-btn") }
+    if (id == "mood") { this.allButtons = document.getElementsByClassName("checkbox-emoji") }
+    if (id == "decade") { this.allButtons = document.getElementsByClassName("checkbox-element-decade") }
+    Array.from(this.allButtons).forEach((button) => {
+      if (button.id != longID) {
         button.parentElement.classList.add("d-none")
       }
     })
-    // document.getElementById("zoom").scrollIntoView();
-    // console.log(allButtons.querySelectorAll(`:not([id^='${selectedID}'])`))
   }
 
 

--- a/app/views/movie_results/_colour_form.html.erb
+++ b/app/views/movie_results/_colour_form.html.erb
@@ -3,7 +3,7 @@
       <% @colour_hash_key.values.shuffle.each do |colour| %>
        <div class="checkbox-div">
           <%= radio_button_tag "colour", @colour_hash_key.key(colour), false, class: "colour-btn" %>
-          <label for="colour_<%=@colour_hash_key.key(colour)%>" style="background-color:<%=colour%>;" data-question-target="colour" data-action="click->question#select"><%=@colour_hash_key.key(colour)%></label>
+          <label for="colour_<%=@colour_hash_key.key(colour)%>" style="background-color:<%=colour%>;" data-action="click->question#select"><%=@colour_hash_key.key(colour)%></label>
         </div>
       <% end %>
     </div>

--- a/app/views/movie_results/_decade_form.html.erb
+++ b/app/views/movie_results/_decade_form.html.erb
@@ -3,7 +3,7 @@
       <% @years_for_select.each do |decade| %>
        <div class="checkbox-div">
           <%= radio_button_tag "decade", decade[0], false, class: "checkbox-element-decade" %>
-          <label for="decade_<%=decade[0]%>"><%=decade[0]%></label>
+          <label for="decade_<%=decade[0]%>" data-action="click->question#select"><%=decade[0]%></label>
         </div>
       <% end %>
     </div>

--- a/app/views/movie_results/_mood_form.html.erb
+++ b/app/views/movie_results/_mood_form.html.erb
@@ -2,22 +2,22 @@
   <div class="d-flex flex-wrap justify-content-center">
     <div class="checkbox-div">
       <%= radio_button_tag :mood, "happy", false, class: "checkbox-emoji" %>
-      <label for="mood_happy" style="" data-question-target="emoji" data-action="click->question#select">🤩</label>
+      <label for="mood_happy" style="" data-action="click->question#select">🤩</label>
     </div>
 
     <div class="checkbox-div">
       <%= radio_button_tag :mood, "neutral", false, class: "checkbox-emoji" %>
-      <label for="mood_neutral" style="" data-question-target="emoji" data-action="click->question#select">😐</label>
+      <label for="mood_neutral" style="" data-action="click->question#select">😐</label>
     </div>
 
     <div class="checkbox-div">
       <%= radio_button_tag :mood, "sad", false, class: "checkbox-emoji" %>
-      <label for="mood_sad" style="" data-question-target="emoji" data-action="click->question#select">😭</label>
+      <label for="mood_sad" style="" data-action="click->question#select">😭</label>
     </div>
 
     <div class="checkbox-div">
       <%= radio_button_tag :mood, "bad", false, class: "checkbox-emoji" %>
-      <label for="mood_bad" style="" data-question-target="emoji" data-action="click->question#select">🥴</label>
+      <label for="mood_bad" style="" data-action="click->question#select">🥴</label>
     </div>
   </div>
 </div>


### PR DESCRIPTION
<img width="345" alt="Screenshot 2023-03-20 at 00 32 24" src="https://user-images.githubusercontent.com/27490724/226220632-fca1bd02-62ce-447e-a1b7-ec11b615fa32.png">
<img width="339" alt="Screenshot 2023-03-20 at 00 32 18" src="https://user-images.githubusercontent.com/27490724/226220641-b69eeb48-10e2-4fd5-8b5f-402366ee837f.png">
<img width="314" alt="Screenshot 2023-03-20 at 00 32 08" src="https://user-images.githubusercontent.com/27490724/226220646-2d3bdacc-22da-40fe-88dd-6da96d053a12.png">
Some javascript updates to make the selection remove other options on all questions. Still needs some better focus so all elements can be well framed in the screen upon selection. 

Again ignore the Years visuals these will be updated. 