### PR TITLE
Smooth scroll

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,6 +11,10 @@
 @import "components/index";
 @import "pages/index";
 
+html {
+    scroll-behavior: smooth;
+}
+
 a {
     text-decoration: none;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -24,6 +24,13 @@ h1, h2, h3, h4, h5, h6 {
     color: white;
 }
 
+.page-title {
+    margin: 30px 0;
+    font-size: 40px;
+    text-align: center;
+    font-family: 'Monument Extended Regular';
+  }
+
 body {
     font-family: 'Monument Extended Regular';
     color: white;

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -8,5 +8,68 @@
 }
 
 .navbar-lewagon .navbar-brand img {
-  width: 40px;
+  width: 50px;
+}
+
+.navbar-lewagon .navbar-brand:hover {
+  transform: scale(1.15);
+}
+
+.navbar-nav .dropdown-mobile {
+  display: none;
+}
+
+@media screen and (max-width: 480px) {
+  .navbar-lewagon {
+    background: transparent;
+  }
+
+  .navbar hr {
+    border: none;
+    height: 3px;
+    color: white;
+    background-color: white;
+  }
+
+  .navbar-lewagon .navbar-brand {
+    color: #ffffff;
+    padding-top: 14px;
+  }
+
+  .navbar-toggler {
+    color: #ffffff;
+    padding-top: 14px;
+    font-size: 32px;
+  }
+
+  .navbar-toggler:hover {
+    transform: scale(1.1);
+  }
+
+  .navbar {
+    --bs-navbar-toggler-border-color: black;
+    --bs-navbar-toggler-focus-width: 0;
+  }
+
+  .navbar-nav .avatar {
+    display: none;
+  }
+
+  .navbar-nav .dropdown-menu {
+    display: none;
+  }
+
+  .navbar-nav .dropdown-mobile {
+    display: unset;
+    margin-top: 20px;
+  }
+
+  .navbar-nav .dropdown-mobile span {
+    display: flex;
+    flex-grow: 1;
+    padding: 8px;
+    color: white;
+    text-align: center;
+    font-size: 32px;
+  }
 }

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -66,10 +66,13 @@
 
   .navbar-nav .dropdown-mobile span {
     display: flex;
-    flex-grow: 1;
     padding: 8px;
     color: white;
     text-align: center;
     font-size: 32px;
+  }
+
+  .navbar-nav .dropdown-mobile span:hover {
+    transform: scale(1.05);
   }
 }

--- a/app/assets/stylesheets/pages/_history.scss
+++ b/app/assets/stylesheets/pages/_history.scss
@@ -33,11 +33,6 @@
     font-size: smaller;
   }
 
-  h2 {
-    margin-top: 30px;
-    font-size: 32px;
-    text-align: center;
-  }
   .cards {
     display: flex;
     padding: 10px 0px;

--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -7,7 +7,7 @@
 
   .h1-big {
     margin-bottom: 0;
-    margin-top: 20px;
+    margin-top: 0px;
   }
 
   p, i {

--- a/app/javascript/controllers/question_controller.js
+++ b/app/javascript/controllers/question_controller.js
@@ -47,6 +47,7 @@ export default class extends Controller {
       answeredPartial.classList.add("d-none")
       document.getElementById("step-box").classList.add("d-none")
     }
+    window.scrollTo({ top: (0, 60), behavior: 'smooth' })
   }
 
   // To be built out to allow user to switch effectively by clicking on the step indicators

--- a/app/views/custom_results/_form.html.erb
+++ b/app/views/custom_results/_form.html.erb
@@ -1,5 +1,5 @@
 <div class="container w-100 mt-5">
-  <h1 class="justify-self-center mb-5">Make your own!</h1>
+  <h2 class="justify-self-center mb-5 page-title">Make your own!</h2>
   <%= form_for @custom_result, url: custom_results_path, method: :post do |f| %>
     <div data-controller="nested-form">
       <%= f.text_field :question, required: true, autofocus: true, class: "form-field mb-5", placeholder: 'Enter a question...', oninvalid: "this.setCustomValidity('Please enter a valid question')", oninput: "setCustomValidity('')" %>

--- a/app/views/pages/category.html.erb
+++ b/app/views/pages/category.html.erb
@@ -1,5 +1,5 @@
 <div class="categories justify-content-center">
-  <h1 class="text-center mb-5">Categories</h1>
+  <h2 class="text-center mb-5 page-title">CATEGORIES</h2>
   <p class="text-center">
     <%= link_to "Watch", movie_questions_path, class: "category-button-watch" %>
   </p>

--- a/app/views/results/index.html.erb
+++ b/app/views/results/index.html.erb
@@ -1,5 +1,5 @@
 <div class="container-history">
-  <h2>History</h2>
+  <h2 class="page-title">HISTORY</h2>
   <ul class="cards mb-2">
     <li class="card card-first-watch">
         <h3>Watch</h3>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -20,6 +20,8 @@
             <li class="nav-item">
               <div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
                 <%= link_to "History", history_path, class: "dropdown-item" %>
+                <%= link_to "Categories", categories_path, class: "dropdown-item" %>
+                <%= link_to "DIY", custom_path, class: "dropdown-item" %>
                 <%= link_to "Log out", destroy_user_session_path, data: {turbo_method: :delete}, class: "dropdown-item" %>
               </div>
              </li>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -5,8 +5,8 @@
       <%# <%= image_tag "https://raw.githubusercontent.com/lewagon/fullstack-images/master/uikit/logo.png" %>
     <% end %>
 
-    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent">
+      <i class="fa-solid fa-bars"></i>
     </button>
 
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
@@ -15,13 +15,22 @@
           <%# <li class="nav-item active">
             <%= link_to "Home", "#", class: "nav-link" %>
           <%# </li>  %>
-          <li class="nav-item dropdown">
-            <%= image_tag "https://picsum.photos/200?grayscale", class: "avatar dropdown-toggle", id: "navbarDropdown", data: { bs_toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
-            <div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
-              <%= link_to "History", history_path, class: "dropdown-item" %>
-              <%= link_to "Log out", destroy_user_session_path, data: {turbo_method: :delete}, class: "dropdown-item" %>
-            </div>
-          </li>
+          <%# <li class="nav-item dropdown"> %>
+            <%= image_tag "https://picsum.photos/200?grayscale", class: "avatar", id: "navbarDropdown", data: { bs_toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
+            <li class="nav-item">
+              <div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
+                <%= link_to "History", history_path, class: "dropdown-item" %>
+                <%= link_to "Log out", destroy_user_session_path, data: {turbo_method: :delete}, class: "dropdown-item" %>
+              </div>
+             </li>
+            <li class="nav-item">
+              <div class="dropdown-mobile" aria-labelledby="navbarDropdown">
+                <span><%= link_to "History", history_path, class: "dropdown-item" %></span>
+                <span><%= link_to "Log out", destroy_user_session_path, data: {turbo_method: :delete}, class: "dropdown-item" %></span>
+              </div>
+              <hr>
+            </li>
+          <%# </li> %>
         <% else %>
           <li class="nav-item">
             <%= link_to "Login", new_user_session_path, class: "nav-link" %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,8 +1,8 @@
 <div class="navbar navbar-expand-sm navbar-light navbar-lewagon">
   <div class="container-fluid">
-    <%= link_to "/", class: "navbar-brand" do %>
+    <%= link_to "/", class: "navbar-brand d-flex" do %>
+      <%# <h4>DiceTo</h4> %>
       <i class="fa-solid fa-dice fa-xl fa-shake"></i>
-      <%# <%= image_tag "https://raw.githubusercontent.com/lewagon/fullstack-images/master/uikit/logo.png" %>
     <% end %>
 
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent">
@@ -26,6 +26,8 @@
             <li class="nav-item">
               <div class="dropdown-mobile" aria-labelledby="navbarDropdown">
                 <span><%= link_to "History", history_path, class: "dropdown-item" %></span>
+                <span><%= link_to "Categories", categories_path, class: "dropdown-item" %></span>
+                <span><%= link_to "DIY", custom_path, class: "dropdown-item" %></span>
                 <span><%= link_to "Log out", destroy_user_session_path, data: {turbo_method: :delete}, class: "dropdown-item" %></span>
               </div>
               <hr>


### PR DESCRIPTION

<img width="1299" alt="Screenshot 2023-03-22 at 16 30 20" src="https://user-images.githubusercontent.com/27490724/226973700-c1c7e297-ed3e-470c-a8b8-be04e04f1e33.png">
<img width="519" alt="Screenshot 2023-03-22 at 16 19 58" src="https://user-images.githubusercontent.com/27490724/226973708-8098897e-38e2-4149-bebb-28d68fefb000.png">
<img width="541" alt="Screenshot 2023-03-22 at 16 19 50" src="https://user-images.githubusercontent.com/27490724/226973714-2769a857-bcd1-4d96-91bf-2d8085009050.png">




This was largely updates to the navbar with a small attempt to ease the scroll up when answering questions (limited success on that but don't want to waste too much time at the moment).

Navbar is now black on mobile. So it just has the logo and the hamburger. No avatar any more (this was a pain to get rid of because of all the classes in the LeWagon one...I couldn't find the controller for it which was weird) So I just put two lists and one gets hidden in either view (desktop vs mobile).

I made the drop-down cover the full mobile screen on advice from my wife. 

I introduced a class for page titles that we can set across the site, for the meantime I've just capitalised them all but I'm not sure this is the best approach yet. (Perhaps we put title in the navbar depending on page?)

A few small adjustments to the home page to make things look better on mobile. 

The drop-down for desktop will need better styling. 