### PR TITLE
feed ui

### DIFF
--- a/app/assets/stylesheets/pages/_history.scss
+++ b/app/assets/stylesheets/pages/_history.scss
@@ -25,12 +25,11 @@
   padding: 0 15px;
   margin: 0 auto;
 
-  h3, p, .time-ago {
-    color: black;
-  }
-
   .time-ago {
+    color: white;
     font-size: smaller;
+    margin-right: 16px;
+    margin-bottom: 10px;
   }
 
   .cards {
@@ -41,29 +40,83 @@
     scroll-snap-type: x mandatory;
   }
   .card {
+    position: relative;
+    background-size: cover;
+    background-position: center;
     display: flex;
     flex-direction: column;
     flex: 0 0 100%;
     padding: 15px;
-    background: var(--white);
     border-radius: 24px;
     // box-shadow: 0 5px 15px rgba(0, 0, 0, 15%);
     scroll-snap-align: start;
     transition: all 0.2s;
     height: 270px;
+    text-shadow: 1px 1px 3px rgba(0,0,0,0.2);
 
     h3 {
-    font-size: 40px;
+      color: white;
+      font-size: 32px;
     }
-    img {
-      border-radius: 4px;
+
+    .answer, .question {
+      position: absolute;
+      word-break: break-word;
+    }
+
+    .x {
+      opacity: 0;
+      position: absolute;
+      right: -10px;
+      top: -10px;
+      width: 30px;
+      height: 30px;
+      color: white;
+      background-color: black;
+      border: 3px solid white;
+      border-radius: 50%;
+      text-align: center;
+    }
+
+   .card:hover > div > .x, .x:hover {
+      opacity: 1;
+      animation: fadeIn 1s linear;
+    }
+    
+    @keyframes fadeIn {
+      0% { opacity: 0; }
+      100% { opacity: 1; }
+    }
+
+    .x:active {
+      transform: scale(1.1);
+      background-color: #5C78FF;
+    }
+
+    .answer {
+      top: 100px;
+      text-shadow: none;
+      text-align: center;
+      color: black;
+      padding: 15px;
+    }
+
+    .question {
+      left: 15px;
+      top: 15px;
+      padding-right: 15px;
     }
   }
+
+  // .card-img-top {
+  //   background-size: cover;
+  // }
 
   .custom-time {
     margin-right: 16px;
     margin-bottom: 10px;
   }
+
   .card-first-watch {
     background-image: url(watch.png);
     background-size: cover;

--- a/app/views/results/index.html.erb
+++ b/app/views/results/index.html.erb
@@ -5,25 +5,24 @@
         <h3>Watch</h3>
     </li>
     <% @movie_results.each do |result| %>
-      <li class="card">
+      <li class="card" style="background-image: linear-gradient(rgba(0,0,0,0.3), rgba(0,0,0,0.3)), url(<%= result.movie.image %>)">
         <h3 class="card-title"><%= result.movie.title %></h3>
-        <%= image_tag "#{result.movie.image}", class: "card-img-top" %>
-            <span class="time-ago position-absolute bottom-0 end-0 custom-time">
-              <% case (@today - result.created_at).round %>
-                <% when 0..60 %>
-                  < 1 minute ago
-                <% when 61..3600 %>
-                  <%= ((@today - result.created_at) / 60).round %> minutes ago
-                <% when 3601..7199 %>
-                  1 hour ago
-                <% when 7200..86400 %>
-                  <%= ((@today - result.created_at) / 3600).round %> hours ago
-                <% when 86401..172799 %>
-                  yesterday
-                <% else %>
-                <%= ((@today - result.created_at) / 86400).round %> days ago
-              <% end %>
-            </span>
+          <span class="time-ago position-absolute bottom-0 end-0">
+            <% case (@today - result.created_at).round %>
+              <% when 0..60 %>
+                < 1 minute ago
+              <% when 61..3600 %>
+                <%= ((@today - result.created_at) / 60).round %> minutes ago
+              <% when 3601..7199 %>
+                1 hour ago
+              <% when 7200..86400 %>
+                <%= ((@today - result.created_at) / 3600).round %> hours ago
+              <% when 86401..172799 %>
+                yesterday
+              <% else %>
+              <%= ((@today - result.created_at) / 86400).round %> days ago
+            <% end %>
+          </span>
         <%# <div class="card-link-wrapper">
           <a href="" class="card-link">Details</a>
         </div> %>
@@ -36,13 +35,13 @@
         <h3>Custom</h3>
     </li>
     <% @custom_results.each do |result| %>
-      <li class="card">
+      <li class="card" style="background-color: <%= ["#5C78FF", "#01C97B", "#FF653E"].sample %>">
           <div class="d-flex justify-content-between">
-            <h3 class="card-title"><%= result.question %></h3>
-            <%= link_to "x", custom_result_path(result), data: {turbo_method: :delete, turbo_confirm: "Are you sure?"} %>
+            <h3 class="card-title question" style="color: #FFCA14;"><%= result.question %></h3>
+            <%= link_to "x", custom_result_path(result), data: {turbo_method: :delete, turbo_confirm: "Are you sure?"}, class: "x"%>
           </div>
-          <div class="mt-5 d-flex justify-content-center">
-            <h3><%= result.answer %></h3>
+          <div class="answer-box mt-5 d-flex justify-content-center">
+            <h3 class="answer" ><%= result.answer %></h3>
           </div>
 
         <%# <div class="card-link-wrapper">


### PR DESCRIPTION

![Screenshot 2023-03-24 at 15 19 33](https://user-images.githubusercontent.com/27490724/227568524-e5a71f7c-d0f7-44d8-8321-2f1068a32395.png)

![Screenshot 2023-03-24 at 15 19 44](https://user-images.githubusercontent.com/27490724/227568555-efa21044-8cef-4bdf-9368-068acf79c0b4.png)

![Screenshot 2023-03-24 at 15 19 54 (2)](https://user-images.githubusercontent.com/27490724/227568577-0fb24483-542c-4f91-be01-e1179301ebe1.png)

Playing with the feed.

- Made the image cover the full movie card (we need to add in the eat results here)
- Made the custom cards have colour, long text work better in them, delete x comes up when you hover in the corner. It would be good to include this in the demo story some how. Made sure the answer text is consistently placed across all the cards. 


I would like to remove the slider tbh. It might be a big task though. Or at least change how it resizes depending on the number of cards