### PR TITLE
plan b for location coordinates

### DIFF
--- a/app/controllers/restaurant_results_controller.rb
+++ b/app/controllers/restaurant_results_controller.rb
@@ -21,6 +21,12 @@ class RestaurantResultsController < ApplicationController
       cuisine = items[rand(items.length)]
     end
 
+    sleep(3)
+    if latitude.nil?
+      latitude = 41.398865875681906
+      longitude = 2.1989594723440535
+    end
+
     restaurant = @client.spots(latitude, longitude, :name => cuisine, :types => 'restaurant', :radius => 500, :detail => true).sample
 
     # If no restaurant is found withing default 500m then there is new search query with incread radius of 5km.


### PR DESCRIPTION
Roll on EAT is now taking 3s to wait if the location coordinates are loaded, if not it will put default value for Barcelona. That way we should not get any error when clicking roll right away from fast roll on EAT. @ronanoboyle  - can you please double check that you are getting restaurants close to you and not Barcelona all the time?